### PR TITLE
Fetch and display CENNZ & CPAY balances

### DIFF
--- a/polkadot/packages/react-api/src/Api.tsx
+++ b/polkadot/packages/react-api/src/Api.tsx
@@ -213,6 +213,15 @@ async function createApi (apiUrl: string, signer: ApiSigner, onError: (error: un
       registry,
       signer,
       types,
+      signedExtensions: {
+        ChargeTransactionPayment: {
+          extrinsic: {
+            tip: 'Compact<Balance>',
+            feeExchange: 'Option<u32>',
+          },
+          payload: {},
+        },
+      },
       typesBundle,
       typesChain
     });

--- a/polkadot/packages/react-api/src/Api.tsx
+++ b/polkadot/packages/react-api/src/Api.tsx
@@ -55,6 +55,7 @@ interface ChainData {
 
 export const DEFAULT_DECIMALS = registry.createType('u32', 4);
 export const DEFAULT_SS58 = registry.createType('u32', addressDefaults.prefix);
+export const DEFAULT_AUX = ['Aux1', 'Aux2', 'Aux3', 'Aux4', 'Aux5', 'Aux6', 'Aux7', 'Aux8', 'Aux9'];
 
 let api: ApiPromise;
 
@@ -130,7 +131,7 @@ async function loadOnReady (api: ApiPromise, endpoint: LinkOption | null, inject
   const ss58Format = settings.prefix === -1
     ? chainSS58
     : settings.prefix;
-  const tokenSymbol = registry.createType('Text', 'CPAY');
+  const tokenSymbol = properties.tokenSymbol.unwrapOr([formatBalance.getDefaults().unit, ...DEFAULT_AUX]);
   const tokenDecimals = [DEFAULT_DECIMALS];
   const isEthereum = ethereumChains.includes(api.runtimeVersion.specName.toString());
   const isDevelopment = (systemChainType.isDevelopment || systemChainType.isLocal || isTestChain(systemChain));

--- a/polkadot/packages/react-api/src/Api.tsx
+++ b/polkadot/packages/react-api/src/Api.tsx
@@ -53,9 +53,8 @@ interface ChainData {
   systemVersion: string;
 }
 
-export const DEFAULT_DECIMALS = registry.createType('u32', 12);
+export const DEFAULT_DECIMALS = registry.createType('u32', 4);
 export const DEFAULT_SS58 = registry.createType('u32', addressDefaults.prefix);
-export const DEFAULT_AUX = ['Aux1', 'Aux2', 'Aux3', 'Aux4', 'Aux5', 'Aux6', 'Aux7', 'Aux8', 'Aux9'];
 
 let api: ApiPromise;
 
@@ -131,8 +130,8 @@ async function loadOnReady (api: ApiPromise, endpoint: LinkOption | null, inject
   const ss58Format = settings.prefix === -1
     ? chainSS58
     : settings.prefix;
-  const tokenSymbol = properties.tokenSymbol.unwrapOr([formatBalance.getDefaults().unit, ...DEFAULT_AUX]);
-  const tokenDecimals = properties.tokenDecimals.unwrapOr([DEFAULT_DECIMALS]);
+  const tokenSymbol = registry.createType('Text', 'CPAY');
+  const tokenDecimals = [DEFAULT_DECIMALS];
   const isEthereum = ethereumChains.includes(api.runtimeVersion.specName.toString());
   const isDevelopment = (systemChainType.isDevelopment || systemChainType.isLocal || isTestChain(systemChain));
 

--- a/polkadot/packages/react-components/src/AddressInfo.tsx
+++ b/polkadot/packages/react-components/src/AddressInfo.tsx
@@ -23,6 +23,7 @@ import Label from './Label';
 import StakingRedeemable from './StakingRedeemable';
 import StakingUnbonding from './StakingUnbonding';
 import { useTranslation } from './translate';
+import { useCENNZBalances } from "@/libs/hooks/useCENNZBalances";
 
 // true to display, or (for bonded) provided values [own, ...all extras]
 export interface BalanceActiveType {
@@ -486,18 +487,29 @@ function AddressInfo (props: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
   const bestNumber = useBestNumber();
   const { children, className = '', extraInfo, withBalanceToggle, withHexSessionId } = props;
-
   const lookup = useRef<Record<string, string>>({
     democrac: t<string>('via Democracy/Vote'),
     phrelect: t<string>('via Council/Vote'),
     'staking ': t<string>('via Staking/Bond'),
     'vesting ': t<string>('via Vesting')
   });
+  const cennzBalances = useCENNZBalances(props.address);
 
   return (
     <div className={`ui--AddressInfo ${className}${withBalanceToggle ? ' ui--AddressInfo-expander' : ''}`}>
       <div className={`column${withBalanceToggle ? ' column--expander' : ''}`}>
-        {renderBalances(props, lookup.current, bestNumber, t)}
+        {/*{renderBalances(props, lookup.current, bestNumber, t)}*/}
+        {cennzBalances?.map((balance, index) => (
+          <React.Fragment key={index}>
+            <Label label={t<string>(["CENNZ", "CPAY"][index])} />
+            <FormatBalance
+              className='result'
+              formatIndex={0}
+              labelPost={<IconVoid />}
+              value={balance}
+            />
+          </React.Fragment>
+        ))}
         {withHexSessionId && withHexSessionId[0] && (
           <>
             <Label label={t<string>('session keys')} />

--- a/src/libs/hooks/useCENNZBalances.ts
+++ b/src/libs/hooks/useCENNZBalances.ts
@@ -1,0 +1,32 @@
+// Copyright 2017-2022 @polkadot/react-hooks authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Balance } from "@cennznet/types";
+
+import { createNamedHook } from "@polkadot/react-hooks/createNamedHook";
+import { useApi } from "@polkadot/react-hooks/useApi";
+import { useCallMulti } from "@polkadot/react-hooks";
+
+/**
+ * Gets CENNZ balances for account
+ *
+ * @param accountAddress The account address of which balance is to be returned
+ * @returns CENNZ balances
+ */
+function useCENNZBalancesImpl(accountAddress: string) {
+	const { api, systemChain } = useApi();
+
+	const isAzalea = systemChain.includes("Azalea");
+	const CENNZ = isAzalea ? "1" : "16000";
+	const CPAY = isAzalea ? "2" : "16001";
+
+	return useCallMulti<Balance[]>([
+		[api.query?.genericAsset?.freeBalance, [CENNZ, accountAddress]],
+		[api.query?.genericAsset?.freeBalance, [CPAY, accountAddress]],
+	]);
+}
+
+export const useCENNZBalances = createNamedHook(
+	"useCENNZBalances",
+	useCENNZBalancesImpl
+);

--- a/src/libs/hooks/useCENNZBalances.ts
+++ b/src/libs/hooks/useCENNZBalances.ts
@@ -1,6 +1,3 @@
-// Copyright 2017-2022 @polkadot/react-hooks authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import type { Balance } from "@cennznet/types";
 
 import { createNamedHook } from "@polkadot/react-hooks/createNamedHook";

--- a/src/libs/hooks/useCENNZBalances.ts
+++ b/src/libs/hooks/useCENNZBalances.ts
@@ -1,8 +1,6 @@
 import type { Balance } from "@cennznet/types";
 
-import { createNamedHook } from "@polkadot/react-hooks/createNamedHook";
-import { useApi } from "@polkadot/react-hooks/useApi";
-import { useCallMulti } from "@polkadot/react-hooks";
+import { createNamedHook, useApi, useCallMulti } from "@polkadot/react-hooks";
 
 /**
  * Gets CENNZ balances for account

--- a/src/libs/hooks/useCENNZBalances.ts
+++ b/src/libs/hooks/useCENNZBalances.ts
@@ -15,10 +15,12 @@ function useCENNZBalancesImpl(accountAddress: string) {
 	const CENNZ = isAzalea ? "1" : "16000";
 	const CPAY = isAzalea ? "2" : "16001";
 
-	return useCallMulti<Balance[]>([
-		[api.query?.genericAsset?.freeBalance, [CENNZ, accountAddress]],
-		[api.query?.genericAsset?.freeBalance, [CPAY, accountAddress]],
-	]);
+	return useCallMulti<Balance[]>(
+		[CENNZ, CPAY].map((assetId) => [
+			api.query.genericAsset.freeBalance,
+			[assetId, accountAddress],
+		])
+	);
 }
 
 export const useCENNZBalances = createNamedHook(


### PR DESCRIPTION
- create and use `useCENNZBalances` hook to fetch & display CENNZ & CPAY balances on Account page

### Notes
 - can't fetch registered assets via `api.rpc` unless we use `@cennznet/api`
 - might be worth making our own version of `AddressInfo` to use?